### PR TITLE
[Fix] 미확인 메세지 버그 수정

### DIFF
--- a/src/components/chat/MessageBox/MessageBox.tsx
+++ b/src/components/chat/MessageBox/MessageBox.tsx
@@ -40,7 +40,7 @@ const MessageBox = () => {
   const selectedUser = useAppSelector((state) => state.selectedUser);
 
   // 해당 conversationId room 참가
-  // 상대방이 메세지를 읽을 경우 모든 메세지의 안읽음 표시 삭제
+  // 상대방이 메세지를 읽을 경우 (채팅방에 참가했을 때) 클라이언트가 보낸 모든 메세지의 안읽음 표시 삭제
   useEffect(() => {
     if (socket) {
       socket.emit("join room", selectedUser.uid);
@@ -63,11 +63,9 @@ const MessageBox = () => {
   }, [socket, selectedUser]);
 
   // 메세지 송/수신했을 때 채팅 내용 갱신
-  // 해당 유저와의 메세지 확인 socket event emit
   useEffect(() => {
     if (socket) {
       socket.on("private message", (message) => {
-        socket.emit("read message", selectedUser.uid);
         const newMessageArr = removeDuplicateDate([...messages, message]);
 
         setMessages(newMessageArr);
@@ -84,11 +82,11 @@ const MessageBox = () => {
   useLayoutEffect(() => {
     // 스크롤을 내리기 위해 빈 값으로 상태갱신
     // 안해주면 이전 메세지 값과 섞여서 유저 변경 시 스크롤이 이상한 곳으로 가있음
+    setMessages([]);
+    loadMessage(selectedUser.uid);
     if (socket) {
       socket.emit("read message", selectedUser.uid);
     }
-    setMessages([]);
-    loadMessage(selectedUser.uid);
   }, [selectedUser, socket]);
 
   // 메세지 수신 시 스크롤 아래로 이동

--- a/src/components/chat/lobby/conversationList/Conversation.tsx
+++ b/src/components/chat/lobby/conversationList/Conversation.tsx
@@ -9,8 +9,8 @@ interface IProps {
   conversation: {
     _id: string;
     lastMessage: string;
-    unreadCount: number;
     updatedAt: string;
+    unreadCount?: number;
     participantObj: {
       _id: string;
       nickname: string;
@@ -58,11 +58,11 @@ const Conversation = ({ conversation }: IProps) => {
       </St.Conversation>
       <St.TimeAndUnread>
         <St.Time>{convertConversationDate(conversation.updatedAt)}</St.Time>
-        {conversation.unreadCount && (
+        {conversation.unreadCount ? (
           <St.Unread>
             {conversation.unreadCount > 300 ? "300+" : conversation.unreadCount}
           </St.Unread>
-        )}
+        ) : null}
       </St.TimeAndUnread>
     </St.ConversationContainer>
   );

--- a/src/components/chat/lobby/conversationList/ConversationList.tsx
+++ b/src/components/chat/lobby/conversationList/ConversationList.tsx
@@ -3,38 +3,67 @@ import { useContext, useEffect, useState } from "react";
 import conversationAPI from "../../../../api/conversations";
 import { SocketContext } from "../../../../context/SocketContext";
 import { useAppSelector } from "../../../../hooks";
-import St from "./styles";
 import { Conversation } from "./";
+import St from "./styles";
+
+interface IConversation {
+  _id: string;
+  lastMessage: string;
+  updatedAt: string;
+  unreadCount?: number;
+  participantObj: {
+    _id: string;
+    nickname: string;
+  }[];
+}
 
 const ConversationList = () => {
-  const [conversations, setConversations] = useState([]);
+  const [conversations, setConversations] = useState<IConversation[]>([]);
 
   const socket = useContext(SocketContext);
   const selectedUser = useAppSelector((state) => state.selectedUser);
 
   // 렌더링 시 대화 목록 불러오기
   useEffect(() => {
-    conversationAPI.getAllConverstaions().then((res) => {
-      let conversationArr = res.data;
-      if (conversationArr.length) {
-        setConversations(conversationArr);
-      }
-    });
+    conversationAPI
+      .getAllConverstaions()
+      .then((res: { data: IConversation[] }) => {
+        let conversationArr = res.data;
+        if (conversationArr.length) {
+          setConversations(conversationArr);
+        }
+      });
   }, []);
 
-  // 대화 도착 시 목록 리렌더링
   useEffect(() => {
     if (socket) {
+      // 대화 도착 시 목록 리렌더링
       socket.on("reload conversation", () => {
-        conversationAPI.getAllConverstaions().then((res) => {
-          let conversationArr = res.data;
-          if (conversationArr.length) {
-            setConversations(conversationArr);
-          }
+        conversationAPI
+          .getAllConverstaions()
+          .then((res: { data: IConversation[] }) => {
+            let conversationArr = res.data;
+            if (conversationArr.length) {
+              setConversations(conversationArr);
+            }
+          });
+      });
+
+      // 특정 대화방 미확인 카운트 삭제
+      socket.on("remove unread", (uid: string) => {
+        const removeUnreadCount = conversations.map((item) => {
+          if (
+            item.participantObj.some((participant) => participant._id === uid)
+          )
+            item.unreadCount = 0;
+          return item;
         });
+
+        setConversations(removeUnreadCount);
       });
       return () => {
         socket.removeListener("reload conversation");
+        socket.removeListener("remove unread");
       };
     }
   }, [socket, selectedUser]);


### PR DESCRIPTION
## PR Type
- [ ] 기능 개발
- [ ] 기능 삭제
- [x] 버그 수정

## 작업 내용
### 1. 미확인 메세지 버그 수정
- 클라이언트가 A유저와의 채팅방을 켜 놨을 때 B유저가 클라이언트가 보낸 메세지를 확인하면 A유저의 미확인 메세지 알람이 사라지는 버그 수정
